### PR TITLE
[setup.py] except block needs parentheses for multiple values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ except ImportError:
 try:
 	with open(os.path.join(base_directory, 'README.rst')) as file_h:
 		long_description = file_h.read()
-except IOError, OSError:
+except (IOError, OSError):
 	sys.stderr.write('README.rst is unavailable, can not generate the long description\n')
 	long_description = None
 


### PR DESCRIPTION
While packaging the last release for Debian I stumbled upon the following:

```
I: pybuild base:217: python3.7 setup.py clean 
  File "setup.py", line 49
    except IOError, OSError:
                  ^
SyntaxError: invalid syntax
E: pybuild pybuild:338: clean: plugin distutils failed with: exit code=1: python3.7 setup.py clean 
dh_auto_clean: pybuild --clean -i python{version} -p "3.7 3.6" returned exit code 13
make: *** [debian/rules:7: clean] Error 25
```

Thanks