### PR TITLE
Added get_ip_list() utility function

### DIFF
--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -33,7 +33,6 @@
 import collections
 import functools
 import inspect
-import ipaddress
 import itertools
 import logging
 import os
@@ -50,11 +49,13 @@ import weakref
 if sys.version_info < (3, 0):
 	import urllib
 	import urlparse
+	import netaddr
 	urllib.parse = urlparse
 	urllib.request = urllib
 	_its_pyv2 = True
 	_its_pyv3 = False
 else:
+	import ipaddress
 	import urllib.parse
 	import urllib.request
 	_its_pyv2 = False
@@ -540,14 +541,25 @@ def get_ip_list(ip_network, mask=None):
 	:param str mask:
 	:return: list
 	"""
-	if mask and '/' not in ip_network:
-		net = ipaddress.ip_network("{0}/{1}".format(ip_network, mask))
-		return [host.__str__() for host in net.hosts()]
-	elif '/' not in ip_network:
-		return [str(ipaddress.ip_address(ip_network))]
-	else:
-		net = ipaddress.ip_network(ip_network)
-		return [host.__str__() for host in net.hosts()]
+	if _its_pyv3:
+		if mask and '/' not in ip_network:
+			net = ipaddress.ip_network("{0}/{1}".format(ip_network, mask))
+			return [host.__str__() for host in net.hosts()]
+		elif '/' not in ip_network:
+			return [str(ipaddress.ip_address(ip_network))]
+		else:
+			net = ipaddress.ip_network(ip_network)
+			return [host.__str__() for host in net.hosts()]
+	elif _its_pyv2:
+		if mask and '/' not in ip_network:
+			net = netaddr.IPNetwork("{0}/{1}".format(ip_network, mask))
+			return [host.__str__() for host in net.iter_hosts()]
+		elif '/' not in ip_network:
+			return [str(netaddr.IPAddress(ip_network))]
+		else:
+			net = netaddr.IPNetwork(ip_network)
+			return [host.__str__() for host in net.iter_hosts()]
+
 
 def open_uri(uri):
 	"""

--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -33,6 +33,7 @@
 import collections
 import functools
 import inspect
+import ipaddress
 import itertools
 import logging
 import os

--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -560,6 +560,23 @@ def get_ip_list(ip_network, mask=None):
 			net = netaddr.IPNetwork(ip_network)
 			return [host.__str__() for host in net.iter_hosts()]
 
+def sort_ip_list(ip_list, unique=True):
+	"""
+	Sorts a provided list of IPv4 addresses. Optionally can remove duplicate values
+	Supports IPv4 addresses with ports included (ex: [10.11.12.13:80, 10.11.12.13:8080])
+	:param ip_list: (list) iterable of IPv4 Addresses
+	:param unique: (bool) removes duplicate values if true
+	:return: sorted list of IP addresses
+	"""
+	if unique:
+		ip_list = list(set(ip_list))
+	return sorted(ip_list, key=lambda ip: (
+		int(ip.split(".")[0]),
+		int(ip.split(".")[1]),
+		int(ip.split(".")[2]),
+		int(ip.split(".")[3].split(':')[0]),
+		int(ip.split(":")[1]) if ":" in ip else 0
+	))
 
 def open_uri(uri):
 	"""

--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -530,6 +530,24 @@ def is_valid_email_address(email_address):
 	# requirements = re
 	return EMAIL_REGEX.match(email_address) != None
 
+def get_ip_list(ip_network, mask=None):
+	"""
+	Quickly convert an IPv4 or IPv6 network (CIDR or Subnet) to a list
+	of individual IPs in their string representation.
+
+	:param str ip_network:
+	:param str mask:
+	:return: list
+	"""
+	if mask and '/' not in ip_network:
+		net = ipaddress.ip_network("{0}/{1}".format(ip_network, mask))
+		return [host.__str__() for host in net.hosts()]
+	elif '/' not in ip_network:
+		return [str(ipaddress.ip_address(ip_network))]
+	else:
+		net = ipaddress.ip_network(ip_network)
+		return [host.__str__() for host in net.hosts()]
+
 def open_uri(uri):
 	"""
 	Open a URI in a platform intelligent way. On Windows this will use


### PR DESCRIPTION
Added a function for something I do pretty regularly, which is converting an IPv4 network into a list of their individual IP addresses as `str()`. The ipaddress library has a way of doing this via the IPv4Network.hosts() generator, but I find this is a nice convenience method. 

You can write it as `get_ip_list('192.168.1.0/24')`, `get_ip_list('192.168.1.0/255.255.255.0')`, `get_ip_list('192.168.1.0', mask='255.255.255.0'), or `get_ip_list('192.168.1.0', mask='24')

Any way will work. :+1: