### PR TITLE
Bugfix: Accounting for an IP list with empty port values

### DIFF
--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -551,7 +551,7 @@ def sort_ipv4_list(ip_list, unique=True):
 		int(ip.split(".")[1]),
 		int(ip.split(".")[2]),
 		int(ip.split(".")[3].split(':')[0]),
-		int(ip.split(":")[1]) if ":" in ip else 0
+                int(ip.split(":")[1]) if ":" in ip and len(ip.split(':')[1]) else 0
 	))
 
 def open_uri(uri):

--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -546,13 +546,14 @@ def sort_ipv4_list(ip_list, unique=True):
 	"""
 	if unique:
 		ip_list = list(set(ip_list))
-	return sorted(ip_list, key=lambda ip: (
+	return sorted([i.rstrip(':') for i in ip_list], key=lambda ip: (
 		int(ip.split(".")[0]),
 		int(ip.split(".")[1]),
 		int(ip.split(".")[2]),
 		int(ip.split(".")[3].split(':')[0]),
-                int(ip.split(":")[1]) if ":" in ip and len(ip.split(':')[1]) else 0
-	))
+        int(ip.split(":")[1]) if ":" in ip else 0
+        )
+    )
 
 def open_uri(uri):
 	"""

--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -552,8 +552,7 @@ def sort_ipv4_list(ip_list, unique=True):
 		int(ip.split(".")[2]),
 		int(ip.split(".")[3].split(':')[0]),
         int(ip.split(":")[1]) if ":" in ip else 0
-        )
-    )
+        ))
 
 def open_uri(uri):
 	"""


### PR DESCRIPTION
I ran into an edge-case scenario where IP addresses and ports were separated with colons but there was no port value, (an empty string or list, for example).

Example
`my_iplist = ['192.168.1.1:80', '192.168.1.12:', '192.168.1.33:100']`

When this (the second element) is encountered, the function fails with the following stacktrace.

```
int(ip.split(":")[1]) if ":" in ip else 0
ValueError: invalid literal for int() with base 10: ''
```

Not an ideal response...

I felt it was more reasonable to parse the list beforehand and strip any trailing colons (`:`). This has an unfortunate side-effect of requiring the list to be parsed at least twice in a best-case scenario `O(n)+1` but considering the number of times that the list must be traversed during the `sorted()` lambda function, it seemed like an acceptable loss.

The end result should now return a sorted list without any trailing colons if no port was supplied in the IP list.

Again... very edge case, but worth catching.

If this PR accepted, please squash the commits. I couldn't make up my mind how I wanted to fix it at first and pushed some embarrassing indentation errors because Vim is not kind. xD