### PR TITLE
Added get_ip_networks_from_file() convenience function 

### DIFF
--- a/smoke_zephyr/__init__.py
+++ b/smoke_zephyr/__init__.py
@@ -33,7 +33,7 @@
 import collections
 
 # Semantic Versioning: http://semver.org/spec/v2.0.0.html
-version_info = collections.namedtuple('version_info', ['major', 'minor', 'micro'])(2, 0, 1)
+version_info = collections.namedtuple('version_info', ['major', 'minor', 'micro'])(2, 0, 2)
 """A tuple representing the version information in the format ('major', 'minor', 'micro')"""
 
 version_label = ''

--- a/smoke_zephyr/utilities.py
+++ b/smoke_zephyr/utilities.py
@@ -517,6 +517,26 @@ def is_valid_email_address(email_address):
 	# requirements = re
 	return EMAIL_REGEX.match(email_address) != None
 
+def get_ip_networks_from_file(filename, strict=True):
+	"""
+	Quickly generate a list of IPv4Networks from a file with built-in validation
+
+	:param str filename: The file to be parsed
+	:param bool strict: If true, raises errors when invalid networks are encountered.
+	:return: list
+	"""
+	with open(filename) as fin:
+		lst = []
+		for x in fin.readlines():
+			try:
+				lst.append(ipaddress.ip_network(x.strip()))
+			except ValueError as err:
+				if strict:
+					raise err
+				else:
+					continue
+		return lst
+
 def get_ip_list(ip_network, mask=None):
 	"""
 	Quickly convert an IPv4 or IPv6 network (CIDR or Subnet) to a list


### PR DESCRIPTION
Created a little convenience function that I use quite a bit for parsing files of IP addresses and CIDR networks. 

Offers a "strict" flag that defaults to True and bubbles errors up when it encounters an invalid IPv4Network in a file. When the strict flag is set to False, it ignores invalid lines and proceeds silently. It is left up to the user to handle the errors encountered.

Thought it might make a useful addition to the library.

This commit iterates the micro version to 2.0.2

Recommend squashing commits to keep the history clean.

Example output run in IDLE:

```python
>>> get_ip_networks_from_file(test_scope, strict=False)
[IPv4Network('10.33.6.0/24'), IPv4Network('10.32.8.0/24'), IPv4Network('10.35.3.0/24'), IPv4Network('10.34.6.0/24'), IPv4Network('10.31.6.0/24'), IPv4Network('10.37.6.0/24')]
>>> with open(test_scope) as fin:
...    print("Example File: \n", fin.read())
... 
Example File: 
Not an IP Address
10.33.6.0/24
10.32.8.0/24
10.35.3.0/24
10.34.6.0/24
10.31.6.0/24
10.37.6.0/24

>>> get_ip_networks_from_file(test_scope)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 17, in get_ip_networks_from_file
  File "<stdin>", line 14, in get_ip_networks_from_file
  File "/usr/lib/python3.6/ipaddress.py", line 84, in ip_network
    address)
ValueError: 'Not an IP Address' does not appear to be an IPv4 or IPv6 network
>>> get_ip_networks_from_file(test_scope, strict=False)
[IPv4Network('10.33.6.0/24'), IPv4Network('10.32.8.0/24'), IPv4Network('10.35.3.0/24'), IPv4Network('10.34.6.0/24'), IPv4Network('10.31.6.0/24'), IPv4Network('10.37.6.0/24')]
```